### PR TITLE
Optimize monorepos to only compile changed packages

### DIFF
--- a/examples/example-registry-package/spago.yaml
+++ b/examples/example-registry-package/spago.yaml
@@ -1,7 +1,7 @@
 package:
   name: example-purescript-package
   version: 0.0.1
-  dependencies: [ "console", "effect", "foldable-traversable", "prelude", "psci-support", "registry-dev", "dodo-printer", "example-dependency" ]
+  dependencies: [ "console", "effect", "foldable-traversable", "prelude", "example-dependency" ]
   test:
     dependencies: ["spec"]
 workspace:

--- a/examples/example-registry-package/src/Main.purs
+++ b/examples/example-registry-package/src/Main.purs
@@ -8,5 +8,5 @@ import Example.Dependency(example)
 
 main :: Effect Unit
 main = do
-  log "🍝"
+  log "example"
   log (show example)

--- a/examples/remote-monorepo/spago.yaml
+++ b/examples/remote-monorepo/spago.yaml
@@ -1,0 +1,16 @@
+package:
+  name: example-purescript-package
+  version: 0.0.1
+  dependencies: [ "console", "effect", "foldable-traversable", "prelude", "sample-common", "sample-server"]
+workspace:
+  set:
+    registry: 11.3.0
+  extra_packages:
+    sample-common:
+      git: "https://github.com/thought2/purifix-monorepo-template.git"
+      ref: "72607cbfa38aa90ec411f58635eb1be6174d4b3d"
+      subdir: "pkgs/sample-common"
+    sample-server:
+      git: "https://github.com/thought2/purifix-monorepo-template.git"
+      ref: "72607cbfa38aa90ec411f58635eb1be6174d4b3d"
+      subdir: "pkgs/sample-server"

--- a/examples/remote-monorepo/src/Main.purs
+++ b/examples/remote-monorepo/src/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Console (log)
+
+main :: Effect Unit
+main = do
+  log "🪄"

--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,9 @@
               src = ./examples/example-purenix-package;
               backend = pkgs.purenix;
             };
+            remote-monorepo = pkgs.purifix {
+              src = ./examples/remote-monorepo;
+            };
             purenix-package-set = pkgs.callPackage ./nix/build-support/purifix/build-package-set.nix { inherit fromYAML purescript-registry purescript-registry-index; } {
               package-set-config = {
                 url = "https://raw.githubusercontent.com/considerate/purenix-package-sets/58722e0989beca7ae8d11495691f0684188efa8c/package-sets/0.0.1.json";

--- a/nix/build-support/purifix/default.nix
+++ b/nix/build-support/purifix/default.nix
@@ -76,7 +76,14 @@ let
   build-pkgs = make-pkgs build-pkgs (build-closure.packages ++ [{
     pname = spagoYamlJSON.package.name;
     version = spagoYamlJSON.package.version;
-    src = src;
+    src =
+      if subdir == ""
+      then src
+      else
+        builtins.path {
+          path = src + "/${subdir}";
+        };
+    repo = src;
     subdir = subdir;
     dependencies = spagoYamlJSON.package.dependencies;
   }]);
@@ -84,14 +91,21 @@ let
   test-pkgs = make-pkgs test-pkgs (test-closure.packages ++ [{
     pname = spagoYamlJSON.package.name;
     version = spagoYamlJSON.package.version;
-    src = src;
+    repo = src;
+    src =
+      if subdir == ""
+      then src
+      else
+        builtins.path {
+          path = src + "/${subdir}";
+        };
     subdir = subdir;
     dependencies = spagoYamlJSON.package.test.dependencies ++ spagoYamlJSON.package.dependencies;
   }]);
 
 
-  buildSourceGlobs = map (dep: ''"${dep.src}/${dep.subdir or ""}/src/**/*.purs"'') build-closure.packages;
-  testSourceGlobs = map (dep: ''"${dep.src}/${dep.subdir or ""}/src/**/*.purs"'') test-closure.packages;
+  buildSourceGlobs = map (dep: ''"${dep.src}/src/**/*.purs"'') build-closure.packages;
+  testSourceGlobs = map (dep: ''"${dep.src}/src/**/*.purs"'') test-closure.packages;
 
 
   runMain = spagoYamlJSON.package.main or "Main";

--- a/nix/build-support/purifix/fetch-sources.nix
+++ b/nix/build-support/purifix/fetch-sources.nix
@@ -32,12 +32,13 @@ let
       '';
     };
 
-  fetchPackage = value:
+  fetchPackage = value: (
     if value.type == "inline"
     then value
     else value // {
       src = fetchPackageTarball value;
-    };
+    }
+  );
 
   # Packages are a flattened version of the closure.
   flatten = { key, package }: package // {

--- a/nix/build-support/purifix/make-package-set.nix
+++ b/nix/build-support/purifix/make-package-set.nix
@@ -39,7 +39,7 @@ let
       copyOutput = map (dep: ''${get-dep dep.pname}/output/*'') dependency-closure.packages;
       caches = map (dep: ''${get-dep dep.pname}/output/cache-db.json'') dependency-closure.packages;
 
-      globs = map (dep: ''"${dep.src}/${dep.subdir or ""}/src/**/*.purs"'') dependency-closure.packages;
+      globs = map (dep: ''"${dep.src}/src/**/*.purs"'') dependency-closure.packages;
       value = stdenv.mkDerivation {
         pname = package.pname;
         version = package.version or "0.0.0";
@@ -55,7 +55,7 @@ let
           ${jq}/bin/jq -s add ${toString caches} > output/cache-db.json
         '';
         buildPhase = ''
-          purs compile --codegen "${codegen}${lib.optionalString withDocs ",docs"}" ${toString globs} "${package.src}/${package.subdir or ""}/src/**/*.purs"
+          purs compile --codegen "${codegen}${lib.optionalString withDocs ",docs"}" ${toString globs} "${package.src}/src/**/*.purs"
           ${backendCommand}
         '';
         installPhase = ''


### PR DESCRIPTION
This PR tries to address point 2. in this issue: https://github.com/purifix/purifix/issues/33#issue-1605278578

The `src` attribute of a package now points directly to the individual package regardless of it being part of a monorepo or not.