### PR TITLE
symlink instead of copy

### DIFF
--- a/nix/build-support/purifix/build-package-set.nix
+++ b/nix/build-support/purifix/build-package-set.nix
@@ -17,6 +17,7 @@
 , backendCommand ? lib.optionalString (backend != null) "${backend}/bin/${backend.pname}"
 }:
 let
+  linkFiles = callPackage ./link-files.nix { };
   inherit
     (callPackage ./get-package-set.nix
       { inherit fromYAML purescript-registry purescript-registry-index; }
@@ -30,7 +31,7 @@ let
     inherit packages storage-backend;
     dependencies = builtins.attrNames packages;
   };
-  make-pkgs = callPackage ./make-package-set.nix { } {
+  make-pkgs = callPackage ./make-package-set.nix { inherit linkFiles; } {
     inherit storage-backend
       packages
       codegen

--- a/nix/build-support/purifix/build-purifix-package.nix
+++ b/nix/build-support/purifix/build-purifix-package.nix
@@ -152,6 +152,7 @@ let
         '';
         installPhase = ''
           cp -r -L output test-output
+          ${lib.optionalString (nodeModules != null) "ln -s ${nodeModules} node_modules"}
           node --input-type=module --abort-on-uncaught-exception --trace-sigint --trace-uncaught --eval="import {main} from './test-output/${testMain}/index.js'; main();" | tee $out
         '';
         fixupPhase = "#nothing to be done here";

--- a/nix/build-support/purifix/build-purifix-package.nix
+++ b/nix/build-support/purifix/build-purifix-package.nix
@@ -104,26 +104,15 @@ let
   runMain = yaml.package.run.main or "Main";
   testMain = yaml.package.test.main or "Test.Main";
 
-  prepareOutput = { caches, globs, copyOutput, ... }: ''
+  purifix = (writeShellScriptBin "purifix" ''
     mkdir -p output
-  '' + lib.optionalString (builtins.length caches > 0) ''
-    echo ${toString copyOutput} | xargs ${linkFiles}
-    rm output/cache-db.json output/package.json
+    cp --no-clobber --preserve -r -L -t output ${dev-pkgs.purifix-dev-shell.deps}/output/*
     chmod -R +w output
-    ${jq}/bin/jq -s add ${toString caches} > output/cache-db.json
-  '';
-
-  purifix =
-    writeShellScriptBin "purifix"
-      (prepareOutput
-        {
-          inherit (dev-pkgs.purifix-dev-shell) globs caches copyOutput;
-        } + ''
-        purs compile --codegen ${codegen} ${toString dev-pkgs.purifix-dev-shell.globs} "$@"
-        ${backendCommand}
-      '') // {
-      inherit (dev-pkgs.purifix-dev-shell) globs caches copyOutput;
-    };
+    purs compile --codegen ${codegen} ${toString dev-pkgs.purifix-dev-shell.globs} "$@"
+    ${backendCommand}
+  '') // {
+    globs = dev-pkgs.purifix-dev-shell.globs;
+  };
 
   run =
     let evaluate = "import {main} from 'file://$out/output/${runMain}/index.js'; main();";
@@ -135,7 +124,7 @@ let
         mkdir $out
         mkdir $out/bin
         ${lib.optionalString (nodeModules != null) "ln -s ${nodeModules} $out/node_modules"}
-        cp -L -rv ${build}/output $out/output
+        cp --preserve -L -rv ${build}/output $out/output
         echo "#!${runtimeShell}" >> $out/bin/${yaml.package.name}
         echo "${nodejs}/bin/node --input-type=module --abort-on-uncaught-exception --trace-sigint --trace-uncaught --eval=\"${evaluate}\"" >> $out/bin/${yaml.package.name}
         chmod +x $out/bin/${yaml.package.name}
@@ -168,7 +157,10 @@ let
       nativeBuildInputs = [
         compiler
       ];
-      buildPhase = (prepareOutput build-pkgs.${yaml.package.name}) + ''
+      buildPhase = ''
+        mkdir output
+        cp --no-clobber --preserve -r -L -t output ${build-pkgs.${yaml.package.name}.deps}/output/*
+        chmod -R +w output
         purs docs --format ${format} ${toString globs} "$src/**/*.purs" --output docs
       '';
       installPhase = ''

--- a/nix/build-support/purifix/get-package-set.nix
+++ b/nix/build-support/purifix/get-package-set.nix
@@ -167,7 +167,7 @@ let
         if l == 2 then "2/${package}"
         else if l == 3 then "3/${builtins.substring 0 1 package}/${package}"
         else "${builtins.substring 0 2 package}/${builtins.substring 2 2 package}/${package}";
-      meta = builtins.trace "reading metadata for ${package}-${version}" (read-meta version "${purescript-registry-index}/${path}");
+      meta = read-meta version "${purescript-registry-index}/${path}";
     in
     value // {
       type = "registry";

--- a/nix/build-support/purifix/link-files.nix
+++ b/nix/build-support/purifix/link-files.nix
@@ -1,5 +1,7 @@
 { writeShellScript }:
 writeShellScript "link-files" ''
+  outdir="$1"
+  shift
   copies=()
   links=()
   declare -A visited
@@ -11,14 +13,14 @@ writeShellScript "link-files" ''
      visited[$name]=1
      if [[ "$name" == Prim* ]]; then
         copies+=( "$file" )
-     elif [ ! -e "output/$name" ]; then
+     elif [ ! -e "$outdir/$name" ]; then
         links+=( "$file" )
      fi
   done
   if [[ ''${#copies[*]} > 0 ]]; then
-    cp -r --no-clobber -t output "''${copies[@]}"
+    cp -r --no-clobber -t "$outdir" "''${copies[@]}"
   fi
   if [[ ''${#links[*]} > 0 ]]; then
-    ln -s -t output "''${links[@]}"
+    ln -s -t "$outdir" "''${links[@]}"
   fi
 ''

--- a/nix/build-support/purifix/link-files.nix
+++ b/nix/build-support/purifix/link-files.nix
@@ -1,0 +1,24 @@
+{ writeShellScript }:
+writeShellScript "link-files" ''
+  copies=()
+  links=()
+  declare -A visited
+  for file in "$@"; do
+     name=$(basename "$file")
+     if [[ ''${visited[$name]} == 1 ]]; then
+       continue
+     fi
+     visited[$name]=1
+     if [[ "$name" == Prim* ]]; then
+        copies+=( "$file" )
+     elif [ ! -e "output/$name" ]; then
+        links+=( "$file" )
+     fi
+  done
+  if [[ ''${#copies[*]} > 0 ]]; then
+    cp -r --no-clobber -t output "''${copies[@]}"
+  fi
+  if [[ ''${#links[*]} > 0 ]]; then
+    ln -s -t output "''${links[@]}"
+  fi
+''


### PR DESCRIPTION
This PR replaces copying of `output` directory files with symlinks. This speeds up the builds a bit but it's still important to copy all compiled files to the final `output` directory before running or bundling because `purescript` generates modules with imports to `../<ModuleName>/index.js'. Those relative paths are broken if resolved from the perspective of the various packages.

Closes #37 