### PR TITLE
Support purifix.json configuration

### DIFF
--- a/examples/purescript-package/purifix.json
+++ b/examples/purescript-package/purifix.json
@@ -1,0 +1,17 @@
+{
+  "package": {
+    "dependencies": [
+      "console",
+      "effect",
+      "foldable-traversable",
+      "prelude"
+    ],
+    "name": "purescript-package",
+    "version": "0.0.1"
+  },
+  "workspace": {
+    "set": {
+      "registry": "11.3.0"
+    }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -136,27 +136,31 @@
 
       # defaultPackage = forAllSystems (system: self.packages.${system}.hello);
 
-      devShells = forAllSystems (system: {
-        # This purescript development shell just contains dhall, purescript,
-        # and spago.  This is convenient for making changes to
-        # ./example-purescript-package. But most users can ignore this.
-        purescript-dev-shell = (nixpkgsFor.${system}.purifix {
-          src = ./examples;
-          develop-packages = [ "example-purescript-package" "example-dependency" ];
-        }).example-purescript-package.develop;
-        spago =
-          let
-            pkgs = nixpkgsFor.${system};
-            easy-ps = import easy-purescript-nix {
-              pkgs = pkgs;
-            };
-          in
-          pkgs.mkShell {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+          easy-ps = import easy-purescript-nix {
+            pkgs = pkgs;
+          };
+        in
+        {
+          default = pkgs.mkShell {
+            name = "purifix-shell";
+            buildInputs = [ easy-ps.purs-0_15_7 pkgs.yaml2json pkgs.jq ];
+          };
+          # This purescript development shell just contains dhall, purescript,
+          # and spago.  This is convenient for making changes to
+          # ./example-purescript-package. But most users can ignore this.
+          purescript-dev-shell = (nixpkgsFor.${system}.purifix {
+            src = ./examples;
+            develop-packages = [ "example-purescript-package" "example-dependency" ];
+          }).example-purescript-package.develop;
+          spago = pkgs.mkShell {
             name = "spago-shell";
             buildInputs = [ easy-ps.spago easy-ps.purs-0_15_7 ];
           };
-      });
+        });
 
-      devShell = forAllSystems (system: self.devShells.${system}.purescript-dev-shell);
+      devShell = forAllSystems (system: self.devShells.${system}.default);
     };
 }

--- a/nix/build-support/purifix/build-purifix-package.nix
+++ b/nix/build-support/purifix/build-purifix-package.nix
@@ -24,7 +24,7 @@
 }:
 let
   workspace = package-config.workspace;
-  yaml = package-config.yaml;
+  yaml = package-config.config;
   src = package-config.repo;
   package-set-config = workspace.package_set or workspace.set;
   extra-packages = (workspace.extra_packages or { }) // localPackages;
@@ -55,7 +55,7 @@ let
 
   all-locals = builtins.attrNames localPackages;
   locals = if develop-packages == null then all-locals else develop-packages;
-  raw-develop-dependencies = builtins.concatLists (map (pkg: localPackages.${pkg}.yaml.package.dependencies) locals);
+  raw-develop-dependencies = builtins.concatLists (map (pkg: localPackages.${pkg}.config.package.dependencies) locals);
   develop-dependencies = builtins.filter (dep: !(builtins.elem dep locals)) raw-develop-dependencies;
   develop-closure = fetch-sources {
     inherit packages storage-backend;
@@ -78,16 +78,16 @@ let
   };
 
   top-level = pkg: {
-    pname = pkg.yaml.package.name;
-    version = pkg.yaml.package.version or pkg.yaml.package.publish.version;
+    pname = pkg.config.package.name;
+    version = pkg.config.package.version or pkg.config.package.publish.version;
     src = pkg.src;
     repo = pkg.repo;
-    dependencies = pkg.yaml.package.dependencies;
+    dependencies = pkg.config.package.dependencies;
   };
   build-pkgs = make-pkgs build-pkgs (build-closure.packages ++ map top-level (builtins.attrValues localPackages));
 
   top-level-test = pkg: top-level pkg // {
-    dependencies = pkg.yaml.package.test.dependencies ++ pkg.yaml.package.dependencies;
+    dependencies = pkg.config.package.test.dependencies ++ pkg.config.package.dependencies;
   };
   test-pkgs = make-pkgs test-pkgs (test-closure.packages ++ map top-level-test (builtins.attrValues localPackages));
 


### PR DESCRIPTION
To avoid IFD purifix now supports loading `purifix.json` with the same format as `spago.yaml` but in JSON encoding.