### PR TITLE
Add node_modules to `bundle` derivation so that esbuild can load npm packages

### DIFF
--- a/nix/build-support/purifix/build-purifix-package.nix
+++ b/nix/build-support/purifix/build-purifix-package.nix
@@ -219,6 +219,7 @@ let
         in
         if app
         then ''
+          ${lib.optionalString (nodeModules != null) "export NODE_PATH=${nodeModules}:$NODE_PATH"}
           echo "import {main} from '${moduleFile}'; main()" | ${command} ${minification}
         ''
         else ''


### PR DESCRIPTION
Basically extending the changes in #38 to work for `bundle`.

According to https://nodejs.org/api/modules.html#loading-from-the-global-folders, manipulating `NODE_PATH` is no longer recommended because global systems can interact in unexpected ways.  However, I tried both copying and symlinking `node_modules` into the working directory, but `esbuild` was not able to locate the packages either case.  However, if you think `NODE_PATH` is not ok to use, I can look into this more.